### PR TITLE
Use TLS with the websocket in the webchat

### DIFF
--- a/src/extensions/webchat/routes_client.js
+++ b/src/extensions/webchat/routes_client.js
@@ -26,10 +26,10 @@ module.exports = function(app) {
 
         config.startupOptions = {
             ...config.startupOptions,
-            port: '{{port}}',
+            port: 443,
             server: '{{hostname}}',
             direct_path: '/',
-            tls: false,
+            tls: true,
             direct: true,
             channel: '',
             bouncer: true,


### PR DESCRIPTION
TLS needs to be explicitly enabled in the webchat.

Fixes: #49